### PR TITLE
fix: UP-0000 - define exports to support importing /polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./*": "./dist/*"
+    ".": "./dist/index.js",
+    "./polyfill": "./dist/polyfill.js"
   },
   "scripts": {
     "clean": "rimraf dist/",


### PR DESCRIPTION
### Checklist

* [ ] There is an associated JIRA issue (**required**)
* [x] The title of your PR is formatted properly (**required**)
* [x] Code is up-to-date with the `develop` branch (**required**)
<!-- ignore-task-list-start -->
* [ ] You've successfully run your unit tests locally
* [ ] There are new or updated unit tests validating the change
<!-- ignore-task-list-end -->

### Short description
We need to make `import '@amityco/react-native-formdata-polyfill/polyfill';` work
for now I'm testing package like this `"@amityco/react-native-formdata-polyfill": "file:../polyfill",` and get this error:
`Unable to resolve module @amityco/react-native-formdata-polyfill/polyfill from /Users/apple/Documents/Amity/app/App.tsx: @amityco/react-native-formdata-polyfill/polyfill could not be found within the project.`